### PR TITLE
Add missing word to parskip.dtx documentation

### DIFF
--- a/parskip/parskip.dtx
+++ b/parskip/parskip.dtx
@@ -108,7 +108,7 @@
 %    not given (or given without a value) then \verb=.5\baselineskip=
 %   plus \texttt{2pt} of stretch is assumed.
 % \item[\option{indent}]
-%    With the package option \texttt{indent} it is possible to explicitly
+%    With the package option \texttt{indent} it is possible to explicitly set
 %    the paragraph indentation. Using this option without a value keeps the
 %    document class indentation unchanged, if it is specified with a
 %    value then that value is used. If the package is loaded without


### PR DESCRIPTION
`indent` part of customization section was missing a word